### PR TITLE
Headers passed in as function instead of value

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -67,11 +67,12 @@ class _MyHomePageState extends State<MyHomePage> {
         encrypted: false,
         authOptions: PusherAuthOptions(
           "http://localhost/api/broadcasting/auth",
-          headers: {
-            "Accept": "application/json",
-            // "Content-Type": "application/json",
-            "Authorization": "Bearer ${tokenController.text}",
-          },
+          headers:
+              () async => {
+                "Accept": "application/json",
+                // "Content-Type": "application/json",
+                "Authorization": "Bearer ${tokenController.text}",
+              },
         ),
         key: KEY,
         enableLogging: true,

--- a/lib/channels/private_channel.dart
+++ b/lib/channels/private_channel.dart
@@ -44,7 +44,7 @@ class PrivateChannel extends Channel {
     final response = await http.post(
       Uri.parse(authOptions.endpoint),
       body: payload,
-      headers: authOptions.headers,
+      headers: await authOptions.headers(),
     );
 
     options.log(

--- a/lib/src/auth_options.dart
+++ b/lib/src/auth_options.dart
@@ -4,14 +4,12 @@ class PusherAuthOptions {
   final String endpoint;
 
   /// The headers for the authentication (default: `{'Accept': 'application/json'}`).
-  final Map<String, String> headers;
+  final Future<Map<String, String>> Function() headers;
 
-  const PusherAuthOptions(
+   PusherAuthOptions(
     this.endpoint, {
-    this.headers = const {
-      'Accept': 'application/json',
-    },
-  });
+    Future<Map<String, String>> Function()? headers,
+  }) : headers = headers ?? (() async => {'Accept': 'application/json'});
 
   /// Returns a new [PusherAuthOptions] with the given endpoint.
   @override


### PR DESCRIPTION
Headers now passed in via function instead of being declared when Options object is created.

A lot of the time auth tokens are stored in async storage, such as SharedPrefs, and as such we cannot rely on the token not changing during normal operation without a proper recourse to fix it asides from destroying the client and recreating it. 

With this change we can now pass in a function to create the headers when needed, meaning each time we can pull a fresh token from storage.

Quick example of the pattern that you can paste into dartpad and run:

```dart
void main() async {
  final storage = Storage();
  final options = Options(
    () => storage.getToken().then(
      (token) => {
        'Accept': 'application/json',
        'Authorization': 'Bearer $token',
      },
    ),
  );

  print(await options.headers()); // {Accept: application/json, Authorization: Bearer my-lovely-token}

  storage.token = 'updated-token';

  print(await options.headers()); // {Accept: application/json, Authorization: Bearer updated-token}
}

class Options {
  final Future<Map<String, String>> Function() headers;

  Options(Future<Map<String, String>> Function()? headers)
    : headers = headers ?? (() async => {'Accept': 'application/json'});
}

class Storage {
  String? _token = 'my-lovely-token';
  set token(String token) => _token = token;

  Future<String?> getToken() {
    return Future.delayed(Duration(seconds: 1), () => _token);
  }
}
```