### PR TITLE
Refactor PusherOptions to improve URI construction and logging format

### DIFF
--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -90,22 +90,24 @@ class PusherOptions {
       }
     } catch (e) {
       dev.log("Invalid host: $host", error: e);
+      hostUri = Uri(
+        scheme: encrypted ? 'wss' : 'ws',
+        host: cluster != null ? 'ws-$cluster.pusher.com' : 'ws.pusher.com',
+        port: encrypted ? wssPort : wsPort,
+      );
     }
 
-    return Uri(
-      scheme: hostUri?.scheme.isNotEmpty == true
-          ? hostUri!.scheme
-          : (encrypted ? 'wss' : 'ws'),
-      host: hostUri?.host.isNotEmpty == true
-          ? hostUri!.host
-          : (cluster != null ? 'ws-$cluster.pusher.com' : 'ws.pusher.com'),
-      port: hostUri?.port == 0 ? (encrypted ? wssPort : wsPort) : uri.port,
+    Uri finalUri = Uri(
+      scheme: hostUri.scheme,
+      host: hostUri.host,
+      port: hostUri.hasPort ? hostUri.port : (encrypted ? wssPort : wsPort),
       queryParameters: {
         ...parameters,
-        if (hostUri?.query.isNotEmpty == true) ...hostUri!.queryParameters,
+        if (hostUri.hasQuery) ...hostUri.queryParameters,
       },
       path: '/app/$key',
     );
+    return finalUri;
   }
 
   log(String level, [String? channel, String? message]) {


### PR DESCRIPTION
Copying @padit69 PR https://github.com/AbdoPrDZ/pusher_client_socket/pull/4 to be able release that.

This PR refactors the `PusherOptions` class in `/lib/src/options.dart` with the following improvements:

### URI Construction Changes

- Added proper error handling by constructing a fallback `hostUri` in the catch block when host parsing fails
- Simplified URI building logic by ensuring `hostUri` is always initialized before use, eliminating complex null-checking ternary operators
- Replaced `uri.port` with `hostUri.port` and changed port check from `port == 0` to using the `hasPort` property for better semantics
- Updated query parameter check from `hostUri?.query.isNotEmpty == true` to the cleaner `hostUri.hasQuery` property