### PR TITLE
Handle reconnection in WebSocket client and fix not reconnecting after websocket times out

### DIFF
--- a/lib/pusher_client_socket.dart
+++ b/lib/pusher_client_socket.dart
@@ -54,23 +54,13 @@ class PusherClient {
   String _stateName(ConnectionState state) {
     // Provide a readable name and additional details for Disconnected
     if (state is Disconnected) {
-      final code = state.code;
-      final reason = state.reason;
-      final error = state.error;
-      final buffer = StringBuffer('DISCONNECTED');
-      if (code != null) {
-        buffer.write(' (code: $code');
-      }
-      if (reason != null) {
-        buffer.write('${code != null ? ', ' : ' ('}reason: $reason');
-      }
-      if (code != null || reason != null) {
-        buffer.write(')');
-      }
-      if (error != null) {
-        buffer.write(' error: $error');
-      }
-      return buffer.toString();
+      final args = [
+        if (state.code != null) "code: ${state.code}",
+        if (state.reason != null && state.reason!.isNotEmpty)
+          "reason: ${state.reason}",
+        if (state.error != null) "error: ${state.error}",
+      ].join(", ");
+      return 'DISCONNECTED${args.isNotEmpty ? '($args)' : ''}';
     }
 
     if (state is Connecting) return 'CONNECTING';


### PR DESCRIPTION
This pull request refactors the connection state handling and reconnection logic in the `PusherClient` class to improve code readability and reliability. The main changes include a more descriptive connection state naming, enhanced logging, and the removal of custom reconnection logic in favor of using the built-in WebSocket timeout feature.

**Connection State Handling Improvements:**

* Added the `_stateName` helper method to provide more descriptive and detailed names for connection states, especially for `Disconnected` states with code, reason, and error details.
* Updated the connection state change logging to use the new `_stateName` method for clearer log messages.

**WebSocket Initialization and Reconnection Logic:**

* Changed WebSocket initialization to use a timeout based on `reconnectGap` and `maxReconnectionAttempts`, removing manual reconnection attempts and relying on the WebSocket's built-in timeout mechanism. [[1]](diffhunk://#diff-6082600db4bd511b11aba7c6eba5ffd48d3b99527d25d265dd9bd063cdac3d64L63-R86) [[2]](diffhunk://#diff-6082600db4bd511b11aba7c6eba5ffd48d3b99527d25d265dd9bd063cdac3d64L139-L153)
* This also fixes an issue where the WebSocket client times out without an exception being thrown while the library still thinks it is connected resulting in a dead connection that is not recovered automatically

**Error Handling Adjustments:**

* Improved error event handling in the `Disconnected` state by directly passing the error to the event handler and removing redundant error checks.

**Minor Cleanup:**

* Fixed a typo in an exception message ("The channel does not initialized yet" → "The channel is not initialized yet").