### PR TITLE
fix: preserve raw channel_data string to prevent HMAC signature mismatch

### DIFF
--- a/lib/channels/private_channel.dart
+++ b/lib/channels/private_channel.dart
@@ -71,7 +71,8 @@ class PrivateChannel extends Channel {
       client.sendEvent("pusher:subscribe", {
         "channel": name,
         "auth": authData!.auth,
-        "channel_data": authData!.channelData?.toJsonString(),
+        "channel_data":
+            authData!.rawChannelData ?? authData!.channelData?.toJsonString(),
       });
       // } catch (e) {
       //   handleEvent("pusher:error", e);

--- a/lib/utils/auth_data.dart
+++ b/lib/utils/auth_data.dart
@@ -4,8 +4,13 @@ class AuthData {
   /// The authentication token.
   final String auth;
 
-  /// The channel data.
+  /// The channel data (parsed).
   final ChannelData? channelData;
+
+  /// The raw channel_data string exactly as returned by the auth endpoint.
+  /// Must be sent verbatim in the pusher:subscribe event so the HMAC
+  /// signature stays valid (PHP escapes "/" as "\/" but Dart does not).
+  final String? rawChannelData;
 
   /// The shared secret for encrypted channels.
   final String? sharedSecret;
@@ -13,6 +18,7 @@ class AuthData {
   const AuthData({
     required this.auth,
     required this.channelData,
+    this.rawChannelData,
     this.sharedSecret,
   });
 
@@ -22,6 +28,7 @@ class AuthData {
         channelData: json["channel_data"] != null
             ? ChannelData.fromJsonString(json["channel_data"])
             : null,
+        rawChannelData: json["channel_data"],
         sharedSecret: json["shared_secret"],
       );
 }


### PR DESCRIPTION
PHP's json_encode escapes "/" as "\/" in the channel_data string, but Dart's jsonEncode does not. When the package parsed and re-serialized channel_data, the string changed, breaking the HMAC signature and causing 4009 "Connection is unauthorized" errors on presence channels.

Now stores the raw channel_data string from the auth response and sends it verbatim in the pusher:subscribe event.